### PR TITLE
Bubble up API errors

### DIFF
--- a/lib/WWW/Shodan/API.pm
+++ b/lib/WWW/Shodan/API.pm
@@ -51,11 +51,18 @@ sub _json {
 sub _request {
     my ($self, $endpoint) = @_;
     my $response = $self->_ua->get(BASE_URL . $endpoint);
-    if ( $response->is_success ) {
-        return $self->_json->decode( $response->decoded_content );
+    my $data;
+    eval {
+        $data = $self->_json->decode( $response->decoded_content );
+    };
+    if ( $response->is_success && $data ) {
+        return $data;
     }
     else {
-        croak $response->status_line;
+        croak sprintf "%s - %s",
+            $response->status_line,
+            ($data && $data->{error}) ? $data->{error} : 'API provided no error message',
+
     }
 }
 


### PR DESCRIPTION
The current code returns the HTTP Status Line, but the Shodan API
actually sends back a useful error message when something goes wrong.
This patch displays the API error message in the croak.